### PR TITLE
Fix Prisma client export

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,7 +1,14 @@
-// lib/supabaseClient.ts
-import { createClient } from "@supabase/supabase-js";
+import { PrismaClient } from "@prisma/client";
 
-export const supabase = createClient(
-  process.env.SUPABASE_URL!,
-  process.env.SUPABASE_ANON_KEY!
-);
+declare global {
+  // eslint-disable-next-line no-var
+  var prisma: PrismaClient | undefined;
+}
+
+export const prisma = globalThis.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== "production") {
+  globalThis.prisma = prisma;
+}
+
+export default prisma;


### PR DESCRIPTION
## Summary
- replace the mistaken Supabase client export in `lib/prisma.ts` with a proper reusable PrismaClient instance
- ensure the Prisma client is cached on the global scope during development to avoid exhausting database connections

## Testing
- npm run lint *(fails: command prompts for ESLint reconfiguration and was aborted to avoid modifying project settings)*

------
https://chatgpt.com/codex/tasks/task_e_68d38c9c4c0c8320b4e2e5da61d0b997